### PR TITLE
support for firmware v1.00

### DIFF
--- a/MinnowFirmware.patch
+++ b/MinnowFirmware.patch
@@ -1,37 +1,24 @@
-diff --git a/MdePkg/Include/Library/DebugLib.h b/MdePkg/Include/Library/DebugLib.h
-index 219d147..6a126c2 100644
---- a/MdePkg/Include/Library/DebugLib.h
-+++ b/MdePkg/Include/Library/DebugLib.h
-@@ -332,7 +332,7 @@ DebugPrintLevelEnabled (
-   @param  StatusParameter  EFI_STATUS value to evaluate.
- 
- **/
--#if !defined(MDEPKG_NDEBUG)
-+#if 0 //!defined(MDEPKG_NDEBUG)
-   #define ASSERT_EFI_ERROR(StatusParameter)                                              \
-     do {                                                                                 \
-       if (DebugAssertEnabled ()) {                                                       \
 diff --git a/Vlv2TbltDevicePkg/PlatformPkgGccX64.dsc b/Vlv2TbltDevicePkg/PlatformPkgGccX64.dsc
-index 25a7813..fdb106c 100644
+index 1daf713..47e0722 100644
 --- a/Vlv2TbltDevicePkg/PlatformPkgGccX64.dsc
 +++ b/Vlv2TbltDevicePkg/PlatformPkgGccX64.dsc
-@@ -1571,6 +1571,7 @@ MdeModulePkg/Universal/FaultTolerantWriteDxe/FaultTolerantWriteSmmDxe.inf
+@@ -1638,6 +1638,7 @@ MdeModulePkg/Universal/FaultTolerantWriteDxe/FaultTolerantWriteSmmDxe.inf
  
    Vlv2TbltDevicePkg/Application/FirmwareUpdate/FirmwareUpdate.inf
    Vlv2TbltDevicePkg/Application/SsdtUpdate/SsdtUpdate.inf
 +  Vlv2TbltDevicePkg/Application/AudioSsdtUpdate/AudioSsdtUpdate.inf
  
- [BuildOptions]
- #
+   !if $(CAPSULE_ENABLE)
+     MdeModulePkg/Universal/EsrtDxe/EsrtDxe.inf
 diff --git a/Vlv2TbltDevicePkg/PlatformPkgX64.dsc b/Vlv2TbltDevicePkg/PlatformPkgX64.dsc
-index a8de866..651cef9 100644
+index e805871..efb8cbf 100644
 --- a/Vlv2TbltDevicePkg/PlatformPkgX64.dsc
 +++ b/Vlv2TbltDevicePkg/PlatformPkgX64.dsc
-@@ -1576,6 +1576,7 @@ MdeModulePkg/Universal/FaultTolerantWriteDxe/FaultTolerantWriteSmmDxe.inf
+@@ -1651,6 +1651,7 @@ MdeModulePkg/Universal/FaultTolerantWriteDxe/FaultTolerantWriteSmmDxe.inf
  
    Vlv2TbltDevicePkg/Application/FirmwareUpdate/FirmwareUpdate.inf
    Vlv2TbltDevicePkg/Application/SsdtUpdate/SsdtUpdate.inf
 +  Vlv2TbltDevicePkg/Application/AudioSsdtUpdate/AudioSsdtUpdate.inf
  
- [BuildOptions]
- #
+   !if $(CAPSULE_ENABLE)
+     MdeModulePkg/Universal/EsrtDxe/EsrtDxe.inf

--- a/MinnowFirmwareSetup.sh
+++ b/MinnowFirmwareSetup.sh
@@ -4,16 +4,21 @@ cd Firmware
 # make sure you have nasm, uuid-devel, libuuid-devel, acpica-tools
 
 # pull all the needed files from GIT
-git clone https://github.com/tianocore/edk2-platforms.git -b minnowboard-max-udk2015
+git clone https://github.com/tianocore/edk2.git -b UDK2017
+cd edk2
+git checkout vUDK2017
+cd ..
+
+git clone https://github.com/tianocore/edk2-platforms.git -b devel-MinnowBoardMax-UDK2017
 cd edk2-platforms/
-git checkout 74a5c7c849543cd98424bb299ab82e1d131c75bb
+git checkout 2a5f80b862e46de213a3f3635c43394deacdfb05
 cd ..
 
 git clone https://github.com/tianocore/edk2-BaseTools-win32.git
 cd edk2-BaseTools-win32/
-git checkout ea691aec89b06aa83474100df1de000a875b4ea0 
+git checkout 0e088c19ab31fccd1d2f55d9e4fe0314b57c0097
 cd ..
-mv edk2-BaseTools-win32 edk2-platforms/BaseTools/Bin
+mv edk2-BaseTools-win32 edk2/BaseTools/Bin
 
 cd edk2-platforms
 
@@ -22,27 +27,26 @@ cd edk2-platforms
 # Symlink to code
 cd Vlv2TbltDevicePkg/Application
 ln -s  ../../../../AudioSsdtUpdate/ AudioSsdtUpdate
-cd ../../
+cd ../../../
+mkdir silicon
 
 # get binary objects
-curl -k -O https://firmware.intel.com/sites/default/files/MinnowBoard_MAX-0.95-Binary.Objects.zip
-unzip MinnowBoard_MAX-0.95-Binary.Objects.zip
-mv MinnowBoard_MAX-0.95-Binary.Objects/* . # move all objects to current directory
+curl -k -O https://firmware.intel.com/sites/default/files/minnowboard_max-1.00-binary.objects.zip
+unzip minnowboard_max-1.00-binary.objects.zip
+mv MinnowBoard_MAX-1.00-Binary.Objects/* silicon # move all objects to current directory
 
 # get OpenSSL, patch it and compile it in workspace
-curl -O https://www.openssl.org/source/openssl-1.0.2d.tar.gz
-cd CryptoPkg/Library/OpensslLib
-tar xf ../../../openssl-1.0.2d.tar.gz
-cd openssl-1.0.2d
-patch -p0 -i ../EDKII_openssl-1.0.2d.patch
-cd ..
-./Install.sh
-cd ../../../
+cd edk2/CryptoPkg/Library/OpensslLib
+git clone -b OpenSSL_1_1_0e https://github.com/openssl/openssl openssl
+cd ../../../../
 
 # make required scripts executable
-chmod +x ./edksetup.sh ./Vlv2TbltDevicePkg/bld_vlv.sh ./Vlv2TbltDevicePkg/Build_IFWI.sh ./Vlv2TbltDevicePkg/GenBiosId
+chmod +x edk2/edksetup.sh
+chmod -R 777 edk2/BaseTools/
+chmod +x edk2-platforms/Vlv2TbltDevicePkg/bld_vlv.sh edk2-platforms/Vlv2TbltDevicePkg/Build_IFWI.sh edk2-platforms/Vlv2TbltDevicePkg/GenBiosId
 
 # last step before compilation, fix GCC issues and add AudioSsdtUpdate
+cd edk2-platforms
 patch -p1 < ../../MinnowFirmware.patch
 
 echo "MinnowFirmware now setup"

--- a/build.sh
+++ b/build.sh
@@ -6,8 +6,8 @@ echo "START COMPILATION"
 #./Build_IFWI.sh MNW2 Debug
 #cp Stitch/*.bin ../../
 
-cp ../Build/Vlv2TbltDevicePkg/RELEASE_GCC49/X64/Vlv2TbltDevicePkg/Application/AudioSsdtUpdate/AudioSsdtUpdate/OUTPUT/*.efi ../../../X64
-cp ../Build/Vlv2TbltDevicePkg/RELEASE_GCC49/X64/Vlv2TbltDevicePkg/Application/AudioSsdtUpdate/AudioSsdtUpdate/OUTPUT/*.aml ../../../X64
+cp ../../Build/Vlv2TbltDevicePkg/RELEASE_GCC5/X64/Vlv2TbltDevicePkg/Application/AudioSsdtUpdate/AudioSsdtUpdate/OUTPUT/*.efi ../../../X64
+cp ../../Build/Vlv2TbltDevicePkg/RELEASE_GCC5/X64/Vlv2TbltDevicePkg/Application/AudioSsdtUpdate/AudioSsdtUpdate/OUTPUT/*.aml ../../../X64
 
 cd ../../../X64
 echo "the images are now under `pwd`"


### PR DESCRIPTION
Add support for compiling firmware v1.00

tested on ubuntu 16.04 with gcc 5.4.0

Signed-off-by: Xun Zhang <xun2.zhang@intel.com>